### PR TITLE
Update copyright holder to Grafana Labs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022-2023 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmd/protoc-gen-connect-go-mux/main.go
+++ b/cmd/protoc-gen-connect-go-mux/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 Buf Technologies, Inc.
+// Copyright 2022-2023 Grafana Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@
 // The 'connect-go-mux' suffix becomes part of the arguments for the Protobuf
 // compiler. To generate the base Go types and Connect code using protoc:
 //
-//	 protoc --go_out=gen --connect-go-mux_out=gen path/to/file.proto
+//	protoc --go_out=gen --connect-go-mux_out=gen path/to/file.proto
 //
 // With buf, your buf.gen.yaml will look like this:
 //
-//   version: v1
-//   plugins:
-//     name: go
-//     out: gen
-//     name: connect-go-mux
-//     out: gen
+//	version: v1
+//	plugins:
+//	  name: go
+//	  out: gen
+//	  name: connect-go-mux
+//	  out: gen
 //
 // This generates helper for registering services with gorilla.mux.
 package main


### PR DESCRIPTION
The license file is missing the copyright holder, and the source still assigns
copyright to Buf. I assume that's not what you want ;)
