### PR TITLE
cmd/protoc-gen-connect-go-mux: replace to connectrpc.com/connect

### DIFF
--- a/cmd/protoc-gen-connect-go-mux/main.go
+++ b/cmd/protoc-gen-connect-go-mux/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	connectPackage = protogen.GoImportPath("github.com/bufbuild/connect-go")
+	connectPackage = protogen.GoImportPath("connectrpc.com/connect")
 	muxPackage     = protogen.GoImportPath("github.com/gorilla/mux")
 
 	generatedFilenameExtension = ".connect.mux.go"


### PR DESCRIPTION
The connect-go has been moved to `https://github.com/connectrpc/connect-go` and uses a vanity import path.